### PR TITLE
feat: upgrade edit-expense-cancel-functionality

### DIFF
--- a/src/components/expenses/EditExpense.tsx
+++ b/src/components/expenses/EditExpense.tsx
@@ -50,6 +50,8 @@ function EditExpense({ history }: EditExpenseProps) {
     incurredOn,
   };
 
+  console.log('history-location-state', history?.location?.state?.isBackButtonShown);
+
   useEffect(() => {
     dispatch(fetchCategories());
   }, [dispatch]);
@@ -91,6 +93,7 @@ function EditExpense({ history }: EditExpenseProps) {
           prefCurrency={prefCurrency}
           categories={categories}
           selectedDate={selectedDate}
+          isBackButtonShown={history?.location?.state?.isBackButtonShown}
           handleOnSubmit={handleOnSubmit}
           handleOnChange={handleOnChange}
           handleDateSelection={handleDateSelection}

--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -83,6 +83,7 @@ type ExpenseFormComponentProps = {
   prefCurrency: string | null,
   categories: Category[],
   selectedDate: Date,
+  isBackButtonShown?: boolean,
   handleOnSubmit(event: React.FormEvent<HTMLFormElement>): void,
   handleOnChange(event: React.ChangeEvent<HTMLInputElement>): void,
   handleDateSelection(date: any, value: any): void
@@ -100,6 +101,7 @@ function ExpenseForm({
   prefCurrency,
   categories,
   selectedDate,
+  isBackButtonShown,
   handleOnSubmit,
   handleOnChange,
   handleDateSelection,
@@ -223,7 +225,13 @@ function ExpenseForm({
             </Button>
             {isLoading && <CircularLoader styleClass={classes.buttonProgress} />}
           </>
-          <Link to="/expenses" className={classes.link}>
+          <Link
+            to={{
+              pathname: '/expenses',
+              state: { from: 'edit-expense', isBackButtonShown },
+            }}
+            className={classes.link}
+          >
             <Button
               id="cancel-button"
               variant="outlined"

--- a/src/components/expenses/ExpenseList.tsx
+++ b/src/components/expenses/ExpenseList.tsx
@@ -32,6 +32,7 @@ type ExpenseListProps = {
   isLoading: boolean,
   expenses: IExpense[],
   hasMore: boolean,
+  isBackButtonShown: boolean,
   handleOpen(exp: IExpense): void,
   handleShowMore(): void,
 };
@@ -40,6 +41,7 @@ function ExpenseList({
   isLoading,
   expenses,
   hasMore,
+  isBackButtonShown,
   handleOpen,
   handleShowMore,
 }: ExpenseListProps) {
@@ -51,6 +53,7 @@ function ExpenseList({
         <SingleExpense
           key={exp?._id}
           expense={exp}
+          isBackButtonShown={isBackButtonShown}
           handleOpen={() => handleOpen(exp)}
         />
       ))}

--- a/src/components/expenses/NewExpense.tsx
+++ b/src/components/expenses/NewExpense.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { RouteChildrenProps } from 'react-router-dom';
 
 import { makeStyles, createStyles } from '@material-ui/core/styles';
 import { Paper } from '@material-ui/core';
@@ -19,7 +20,7 @@ const useStyles = makeStyles(() => createStyles({
 }));
 
 type RouteProps = {
-  history: any,
+  history: RouteChildrenProps['history'],
 };
 
 function NewExpense({ history }: RouteProps) {

--- a/src/components/expenses/SingleExpense.tsx
+++ b/src/components/expenses/SingleExpense.tsx
@@ -54,6 +54,7 @@ const useStyles = makeStyles((theme) => createStyles({
 
 type ExpenseComponentProps = {
   expense: IExpense,
+  isBackButtonShown: boolean,
   handleOpen(): void
 }
 
@@ -78,7 +79,7 @@ function CustomFieldTypography({ field, value, classes }: CustomFieldTypographyP
   );
 }
 
-function SingleExpense({ expense, handleOpen }: ExpenseComponentProps) {
+function SingleExpense({ expense, isBackButtonShown, handleOpen }: ExpenseComponentProps) {
   const classes = useStyles();
   const history = useHistory();
   const dispatch = useAppDispatch();
@@ -88,7 +89,7 @@ function SingleExpense({ expense, handleOpen }: ExpenseComponentProps) {
     dispatch(resetStateToSelectedExpenseValues(
       { ...expense, isLoading: false, serverError: null },
     ));
-    history.push('/edit-expense');
+    history.push('/edit-expense', { isBackButtonShown });
   }
 
   return (

--- a/src/components/expenses/index.tsx
+++ b/src/components/expenses/index.tsx
@@ -46,7 +46,11 @@ const useStyles = makeStyles((theme) => createStyles({
   },
 }));
 
-export default function () {
+type ExpensesProps = {
+  location: any,
+}
+
+export default function ({ location }: ExpensesProps) {
   const classes = useStyles();
   const dispatch = useAppDispatch();
 
@@ -68,8 +72,13 @@ export default function () {
   );
 
   useEffect(() => {
-    dispatch(fetchExpenses({ startDate: undefined, endDate: undefined, cursor: undefined }));
-  }, [dispatch]);
+    if (!location?.state) {
+      dispatch(fetchExpenses({ startDate: undefined, endDate: undefined, cursor: undefined }));
+    }
+    if (location?.state?.isBackButtonShown) {
+      setShowBackButton(location?.state?.isBackButtonShown);
+    }
+  }, [dispatch, location]);
 
   function handleOpen(expense: IExpense) {
     setExpenseToDelete(expense);
@@ -151,6 +160,7 @@ export default function () {
           isLoading={isLoading}
           expenses={expenses}
           hasMore={hasNextPage}
+          isBackButtonShown={isBackButtonShown}
           handleOpen={handleOpen}
           handleShowMore={handleShowMore}
         />

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -22,7 +22,7 @@ function AppRouter() {
         <Route
           exact
           path="/"
-          render={(props) => (isAuthenticated() ? <Expenses /> : <Home {...props} />)}
+          render={(props) => (isAuthenticated() ? <Expenses {...props} /> : <Home {...props} />)}
         />
         <Route
           exact


### PR DESCRIPTION
- pass route state from single expense component to edit expense component when edit button is hit
- refactor expenses useEffect hook not to refetch expenses when being pushed from the edit-expenses location url
- dynamically control showing of the back button when the expenses component is pushed from edit expense location