### PR TITLE
fix: expense form cancel link functionality

### DIFF
--- a/src/components/expenses/EditExpense.tsx
+++ b/src/components/expenses/EditExpense.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { RouteComponentProps } from 'react-router-dom';
 
 import { makeStyles, createStyles } from '@material-ui/core/styles';
 import { Paper } from '@material-ui/core';
@@ -18,11 +19,7 @@ const useStyles = makeStyles(() => createStyles({
   },
 }));
 
-type EditExpenseProps = {
-  history: any
-}
-
-function EditExpense({ history }: EditExpenseProps) {
+function EditExpense({ history }: RouteComponentProps) {
   const classes = useStyles();
   const [selectedDate, selectDate] = useState<Date>(new Date());
   const [prefCurrency] = useState<string | null>(localStorage.getItem('currency'));
@@ -49,8 +46,6 @@ function EditExpense({ history }: EditExpenseProps) {
     notes,
     incurredOn,
   };
-
-  console.log('history-location-state', history?.location?.state?.isBackButtonShown);
 
   useEffect(() => {
     dispatch(fetchCategories());
@@ -93,7 +88,7 @@ function EditExpense({ history }: EditExpenseProps) {
           prefCurrency={prefCurrency}
           categories={categories}
           selectedDate={selectedDate}
-          isBackButtonShown={history?.location?.state?.isBackButtonShown}
+          path="edit-expense"
           handleOnSubmit={handleOnSubmit}
           handleOnChange={handleOnChange}
           handleDateSelection={handleDateSelection}

--- a/src/components/expenses/ExpenseForm.tsx
+++ b/src/components/expenses/ExpenseForm.tsx
@@ -83,7 +83,7 @@ type ExpenseFormComponentProps = {
   prefCurrency: string | null,
   categories: Category[],
   selectedDate: Date,
-  isBackButtonShown?: boolean,
+  path?: string,
   handleOnSubmit(event: React.FormEvent<HTMLFormElement>): void,
   handleOnChange(event: React.ChangeEvent<HTMLInputElement>): void,
   handleDateSelection(date: any, value: any): void
@@ -101,7 +101,7 @@ function ExpenseForm({
   prefCurrency,
   categories,
   selectedDate,
-  isBackButtonShown,
+  path,
   handleOnSubmit,
   handleOnChange,
   handleDateSelection,
@@ -228,7 +228,7 @@ function ExpenseForm({
           <Link
             to={{
               pathname: '/expenses',
-              state: { from: 'edit-expense', isBackButtonShown },
+              state: { from: path },
             }}
             className={classes.link}
           >

--- a/src/components/expenses/ExpenseList.tsx
+++ b/src/components/expenses/ExpenseList.tsx
@@ -32,7 +32,6 @@ type ExpenseListProps = {
   isLoading: boolean,
   expenses: IExpense[],
   hasMore: boolean,
-  isBackButtonShown: boolean,
   handleOpen(exp: IExpense): void,
   handleShowMore(): void,
 };
@@ -41,7 +40,6 @@ function ExpenseList({
   isLoading,
   expenses,
   hasMore,
-  isBackButtonShown,
   handleOpen,
   handleShowMore,
 }: ExpenseListProps) {
@@ -53,7 +51,6 @@ function ExpenseList({
         <SingleExpense
           key={exp?._id}
           expense={exp}
-          isBackButtonShown={isBackButtonShown}
           handleOpen={() => handleOpen(exp)}
         />
       ))}

--- a/src/components/expenses/NewExpense.tsx
+++ b/src/components/expenses/NewExpense.tsx
@@ -92,6 +92,7 @@ function NewExpense({ history }: RouteProps) {
           isLoading={isLoading}
           prefCurrency={prefCurrency}
           categories={categories}
+          path="new-expense"
           selectedDate={selectedDate}
           handleOnSubmit={handleOnSubmit}
           handleOnChange={handleOnChange}

--- a/src/components/expenses/SingleExpense.tsx
+++ b/src/components/expenses/SingleExpense.tsx
@@ -54,12 +54,10 @@ const useStyles = makeStyles((theme) => createStyles({
 
 type ExpenseComponentProps = {
   expense: IExpense,
-  isBackButtonShown: boolean,
   handleOpen(): void
 }
 
 type CustomFieldTypographyProps = {
-  field: string,
   value: string,
   classes: any,
 }
@@ -68,10 +66,9 @@ function capitalizeString(txt: string) {
   return txt.charAt(0).toUpperCase() + txt.slice(1);
 }
 
-function CustomFieldTypography({ field, value, classes }: CustomFieldTypographyProps) {
+function CustomFieldTypography({ value, classes }: CustomFieldTypographyProps) {
   return (
     <div className={classes.customFieldTypographyContainer}>
-      {/* <Typography variant="subtitle1">{`${field}:`}</Typography> */}
       <Typography variant="subtitle1" className={classes.typographyValues}>
         {capitalizeString(value)}
       </Typography>
@@ -79,7 +76,7 @@ function CustomFieldTypography({ field, value, classes }: CustomFieldTypographyP
   );
 }
 
-function SingleExpense({ expense, isBackButtonShown, handleOpen }: ExpenseComponentProps) {
+function SingleExpense({ expense, handleOpen }: ExpenseComponentProps) {
   const classes = useStyles();
   const history = useHistory();
   const dispatch = useAppDispatch();
@@ -89,7 +86,7 @@ function SingleExpense({ expense, isBackButtonShown, handleOpen }: ExpenseCompon
     dispatch(resetStateToSelectedExpenseValues(
       { ...expense, isLoading: false, serverError: null },
     ));
-    history.push('/edit-expense', { isBackButtonShown });
+    history.push('/edit-expense');
   }
 
   return (
@@ -103,7 +100,6 @@ function SingleExpense({ expense, isBackButtonShown, handleOpen }: ExpenseCompon
             <div className={classes.titleContainer}>
               <>
                 <CustomFieldTypography
-                  field="Title"
                   value={expense?.title}
                   classes={classes}
                 />

--- a/src/components/expenses/index.tsx
+++ b/src/components/expenses/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { RouteComponentProps } from 'react-router-dom';
 import { makeStyles, createStyles } from '@material-ui/core/styles';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import { Fab } from '@material-ui/core';
@@ -46,11 +47,7 @@ const useStyles = makeStyles((theme) => createStyles({
   },
 }));
 
-type ExpensesProps = {
-  location: any,
-}
-
-export default function ({ location }: ExpensesProps) {
+export default function ({ location }: RouteComponentProps<'location', {}, { from: string }>) {
   const classes = useStyles();
   const dispatch = useAppDispatch();
 
@@ -74,10 +71,11 @@ export default function ({ location }: ExpensesProps) {
   useEffect(() => {
     if (!location?.state) {
       dispatch(fetchExpenses({ startDate: undefined, endDate: undefined, cursor: undefined }));
+    } else if (location?.state?.from) {
+      setShowBackButton(true);
     }
-    if (location?.state?.isBackButtonShown) {
-      setShowBackButton(location?.state?.isBackButtonShown);
-    }
+
+    return () => setShowBackButton(false);
   }, [dispatch, location]);
 
   function handleOpen(expense: IExpense) {
@@ -109,7 +107,7 @@ export default function ({ location }: ExpensesProps) {
     setShowBackButton(false);
   }
 
-  if (isLoading && count === 0) {
+  if ((isLoading && count === 0) || (isLoading && !isBackButtonShown && !hasNextPage)) {
     return (
       <ExpensesLoader />
     );
@@ -131,7 +129,7 @@ export default function ({ location }: ExpensesProps) {
                 aria-label="search"
                 className={classes.backButton}
                 size="small"
-                disabled={isLoading}
+                // disabled={isLoading}
                 onClick={handleBackButton}
               >
                 <ArrowBackIcon />
@@ -160,7 +158,6 @@ export default function ({ location }: ExpensesProps) {
           isLoading={isLoading}
           expenses={expenses}
           hasMore={hasNextPage}
-          isBackButtonShown={isBackButtonShown}
           handleOpen={handleOpen}
           handleShowMore={handleShowMore}
         />

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -22,7 +22,7 @@ function AppRouter() {
         <Route
           exact
           path="/"
-          render={(props) => (isAuthenticated() ? <Expenses {...props} /> : <Home {...props} />)}
+          render={(props) => (isAuthenticated() ? <Profile /> : <Home {...props} />)}
         />
         <Route
           exact


### PR DESCRIPTION
- add location checks in the expenses component useEffect hook to conditionally fetch expenses and set isBackButton boolean property
- remove the isBackButtonShown prop from expense related components
- modify the expense component loading logic to cater for cases when the back button is pressed